### PR TITLE
Add trailingSlash setting to Docusaurus config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -23,6 +23,12 @@ const config = {
     organizationName: 'KaringX', // Usually your GitHub org/user name.
     projectName: 'karing-docu', // Usually your repo name.
     deploymentBranch: 'gh-pages',
+    
+    // GitHub Pages adds a trailing slash to Docusaurus URLs by default.
+    // It is recommended to set a trailingSlash config (true or false, not undefined).
+    // We set `false` here as many slugs in the repository are already slash-less.
+    // https://docusaurus.io/docs/deployment#docusaurusconfigjs-settings
+    trailingSlash: false,
 
     onBrokenLinks: 'throw', //'ignore' | 'log' | 'warn' | 'throw'
     onBrokenAnchors: 'ignore',


### PR DESCRIPTION
Github Pages deployment requires a one more config parameter which was missing. Its absence is causing a bag in English localization.

How to replicate:
→ Go to the main page https://karing.app
→ Change localization to `English`
→ Click the CTA-button `Karing Tutorial - 5min ⏱️` (https://karing.app/en/quickstart)
→ Navigate `Other platform` header
→ Click `Download` link (https://karing.app/download)

And you'll see “Page not Found” error message.